### PR TITLE
Use LightDM configuration snippets

### DIFF
--- a/debian/50-pi-greeter.conf
+++ b/debian/50-pi-greeter.conf
@@ -1,0 +1,4 @@
+[Seat:*]
+greeter-hide-users=false
+greeter-session=pi-greeter
+autologin-user=pi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pi-greeter (0.7) UNRELEASED; urgency=medium
+
+  * Use LightDM configuration snippets
+
+ -- Robert Ancell <robert.ancell@gmail.com>  Wed, 18 Oct 2017 10:56:59 +1300
+
 pi-greeter (0.6) stretch; urgency=medium
 
   * Use Piboto font; update greeter-hide-users setting for Stretch

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+debian/50-pi-greeter.conf /usr/share/lightdm/lightdm.conf.d/

--- a/debian/pi-greeter.postinst
+++ b/debian/pi-greeter.postinst
@@ -6,9 +6,7 @@ if [ "$1" = "configure" ]; then
   update-alternatives --install /usr/share/xgreeters/lightdm-greeter.desktop \
   lightdm-greeter /usr/share/xgreeters/pi-greeter.desktop 70
   if [ -e /etc/lightdm/lightdm.conf ] ; then
-    sed -i /etc/lightdm/lightdm.conf -e "s/#\?greeter-hide-users=.*/greeter-hide-users=false/"
-    sed -i /etc/lightdm/lightdm.conf -e "s/#\?greeter-session=.*/greeter-session=pi-greeter/"
-    sed -i /etc/lightdm/lightdm.conf -e "s/#\?autologin-user=.*/autologin-user=pi/"
+    sed -i /etc/lightdm/lightdm.conf -e "s/^greeter-session=pi-greeter/#greeter-session=pi-greeter/"
   fi
 fi
 

--- a/debian/pi-greeter.prerm
+++ b/debian/pi-greeter.prerm
@@ -4,9 +4,6 @@ set -e
 
 if [ "$1" = "remove" ]; then
   update-alternatives --remove lightdm-greeter /usr/share/xgreeters/pi-greeter.desktop
-  if [ -e /etc/lightdm/lightdm.conf ] ; then
-    sed -i /etc/lightdm/lightdm.conf -e "s/^greeter-session=pi-greeter/#greeter-session=pi-greeter/"
-  fi
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Configuration snippets allow you to more easily provide configuration for LightDM that is easily removed on uninstall. 

You can check the current lightdm configuration by running:
$ lightdm --show-config
