### PR TITLE
Allow for custom pi-greeter.conf

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,7 +1,7 @@
 xgreetersdir = $(datadir)/xgreeters
 dist_xgreeters_DATA = pi-greeter.desktop
 
-configdir = $(sysconfdir)/lightdm
+configdir = $(datadir)/pi-greeter
 dist_config_DATA = pi-greeter.conf
 
 uidir = $(datadir)/pi-greeter

--- a/debian/pi-greeter.alternatives
+++ b/debian/pi-greeter.alternatives
@@ -1,0 +1,5 @@
+Name: lightdm-greeter
+Link: /usr/share/xgreeters/lightdm-greeter.desktop
+Alternative: /usr/share/xgreeters/pi-greeter.desktop
+Priority: 70
+

--- a/debian/pi-greeter.alternatives
+++ b/debian/pi-greeter.alternatives
@@ -3,3 +3,8 @@ Link: /usr/share/xgreeters/lightdm-greeter.desktop
 Alternative: /usr/share/xgreeters/pi-greeter.desktop
 Priority: 70
 
+Name: pi-greeter.conf
+Link: /etc/lightdm/pi-greeter.conf
+Alternative: /usr/share/pi-greeter/pi-greeter.conf
+Priority: 50
+

--- a/debian/pi-greeter.maintscript
+++ b/debian/pi-greeter.maintscript
@@ -1,0 +1,2 @@
+rm_conffile /etc/lightdm/pi-greeter.conf 0.22
+

--- a/debian/pi-greeter.postinst
+++ b/debian/pi-greeter.postinst
@@ -3,8 +3,6 @@
 set -e
 
 if [ "$1" = "configure" ]; then
-  update-alternatives --install /usr/share/xgreeters/lightdm-greeter.desktop \
-  lightdm-greeter /usr/share/xgreeters/pi-greeter.desktop 70
   if [ -z "$2" ]; then
     if [ -e /etc/lightdm/lightdm.conf ] ; then
       sed -i /etc/lightdm/lightdm.conf -e "s/#greeter-hide-users=.*/greeter-hide-users=false/"

--- a/debian/pi-greeter.prerm
+++ b/debian/pi-greeter.prerm
@@ -3,7 +3,6 @@
 set -e
 
 if [ "$1" = "remove" ]; then
-  update-alternatives --remove lightdm-greeter /usr/share/xgreeters/pi-greeter.desktop
   if [ -e /etc/lightdm/lightdm.conf ] ; then
     sed -i /etc/lightdm/lightdm.conf -e "s/^greeter-session=pi-greeter/#greeter-session=pi-greeter/"
   fi


### PR DESCRIPTION
In order to make the pi-greeter.conf customizable through external debian packages, the config file is created as symlink via update-alternatives. The default config is now installed to /usr/share/pi-greeter and linked by default with a priority of 50.

This will allow OEMs and other users, who want to customize the greeter to ship custom config files.